### PR TITLE
Improve unused return

### DIFF
--- a/tests/detectors/unused_return.cairo
+++ b/tests/detectors/unused_return.cairo
@@ -26,6 +26,16 @@ mod UnusedReturn {
         f_4(amount);
     }
 
+    #[external]
+    fn unused_return_5() {
+        let a = f_5();        
+    }
+
+    #[external]
+    fn no_report() {
+        let a = value::read();
+    }
+
     fn f_1(amount: felt252) -> felt252 {
         value::write(amount);
         23
@@ -41,6 +51,11 @@ mod UnusedReturn {
 
     fn f_4(amount: felt252) -> Option::<felt252> {
         Option::Some(amount)
+    }
+
+    fn f_5() -> felt252 {
+        let a = value::read();
+        a * 2
     }
 
 }

--- a/tests/snapshots/integration_tests__detectors@unused_return.cairo.snap
+++ b/tests/snapshots/integration_tests__detectors@unused_return.cairo.snap
@@ -27,4 +27,10 @@ expression: "get_detectors().iter().flat_map(|d| d.run(&core)).collect::<Vec<Res
         confidence: Medium,
         message: "Return value unused for the function call function_call<user@unused_return::unused_return::UnusedReturn::f_4>([2]) -> ([1]) in unused_return::unused_return::UnusedReturn::unused_return_4",
     },
+    Result {
+        name: "unused-return",
+        impact: Medium,
+        confidence: Medium,
+        message: "Return value unused for the function call function_call<user@unused_return::unused_return::UnusedReturn::f_5>([5], [6]) -> ([2], [3], [4]) in unused_return::unused_return::UnusedReturn::unused_return_5",
+    },
 ]


### PR DESCRIPTION
Don't report unused-return on storage variables functions (read, write, address).
Handle the correct number of returned variables sometimes is possible that there are other struct_deconstruct instructions unrelated to the returned variables and previously the detector was checking also those.