### PR TITLE
Allow selecting/excluding which detectors to run

### DIFF
--- a/src/cli/commands/detect/mod.rs
+++ b/src/cli/commands/detect/mod.rs
@@ -2,7 +2,7 @@ use super::Cmd;
 use clap::{Args, ValueHint};
 use starknet_static_analysis::{
     core::core_unit::{CoreOpts, CoreUnit},
-    detectors::get_detectors,
+    detectors::{detector::Impact, get_detectors},
 };
 use std::path::PathBuf;
 
@@ -15,6 +15,30 @@ pub struct DetectArgs {
     /// Corelib path (e.g. mypath/corelib/src)
     #[arg(long)]
     corelib: Option<PathBuf>,
+
+    /// Detectors to run
+    #[arg(long, num_args(0..), conflicts_with_all(["exclude", "exclude_informational", "exclude_low", "exclude_medium", "exclude_high"]))]
+    detect: Option<Vec<String>>,
+
+    /// Detectors to exclude
+    #[arg(long, num_args(0..))]
+    exclude: Option<Vec<String>>,
+
+    /// Exclude detectors with informational impact
+    #[arg(long)]
+    exclude_informational: bool,
+
+    /// Exclude detectors with low impact
+    #[arg(long)]
+    exclude_low: bool,
+
+    /// Exclude detectors with medium impact
+    #[arg(long)]
+    exclude_medium: bool,
+
+    /// Exclude detectors with high impact
+    #[arg(long)]
+    exclude_high: bool,
 }
 
 impl From<&DetectArgs> for CoreOpts {
@@ -29,7 +53,33 @@ impl From<&DetectArgs> for CoreOpts {
 impl Cmd for DetectArgs {
     fn run(&self) -> anyhow::Result<()> {
         let core = CoreUnit::new(self.into())?;
-        get_detectors()
+        let mut detectors = get_detectors();
+
+        if let Some(detectors_to_run) = &self.detect {
+            detectors.retain(|d| detectors_to_run.contains(&d.name().to_string()));
+        } else {
+            if let Some(detectors_to_exclude) = &self.exclude {
+                detectors.retain(|d| !detectors_to_exclude.contains(&d.name().to_string()));
+            }
+
+            if self.exclude_informational {
+                detectors.retain(|d| d.impact() != Impact::Informational);
+            }
+
+            if self.exclude_low {
+                detectors.retain(|d| d.impact() != Impact::Low);
+            }
+
+            if self.exclude_medium {
+                detectors.retain(|d| d.impact() != Impact::Medium);
+            }
+
+            if self.exclude_high {
+                detectors.retain(|d| d.impact() != Impact::High);
+            }
+        }
+
+        detectors
             .iter()
             .map(|d| d.run(&core))
             .for_each(|results| results.iter().for_each(|r| println!("{r}")));


### PR DESCRIPTION
Add the option to exclude specific detectors (`--exclude dead-code ...`) or a category of detectors based on the impact (`--exclue-informational`, .,..).
Also add `--detect dead-code ...` to run only specific detectors.