### PR TITLE
Use local compiler if available

### DIFF
--- a/src/compilation/standard.rs
+++ b/src/compilation/standard.rs
@@ -1,5 +1,6 @@
-use anyhow::{bail, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use std::env;
+use std::process;
 use std::sync::Arc;
 
 use cairo_lang_compiler::db::RootDatabase;
@@ -7,19 +8,48 @@ use cairo_lang_compiler::project::{setup_project, ProjectConfig, ProjectConfigCo
 use cairo_lang_compiler::CompilerConfig;
 use cairo_lang_filesystem::ids::Directory;
 use cairo_lang_sierra_generator::db::SierraGenGroup;
-use cairo_lang_sierra_generator::replace_ids::replace_sierra_ids_in_program;
+use cairo_lang_sierra_generator::replace_ids::{replace_sierra_ids_in_program, SierraIdReplacer};
 use cairo_lang_starknet::abi::{AbiBuilder, Contract};
 use cairo_lang_starknet::compiler_version::current_compiler_version_id;
 use cairo_lang_starknet::contract::find_contracts;
+use cairo_lang_starknet::contract_class::ContractClass;
 use cairo_lang_starknet::inline_macros::selector::SelectorMacro;
 use cairo_lang_starknet::plugin::StarkNetPlugin;
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
 
 use super::ProgramCompiled;
+use crate::compilation::utils::felt252_serde::sierra_from_felt252s;
+use crate::compilation::utils::replacer::SierraProgramDebugReplacer;
 use crate::core::core_unit::CoreOpts;
 
 pub fn compile(opts: CoreOpts) -> Result<Vec<ProgramCompiled>> {
-    println!("Compiling with cairo {}.", current_compiler_version_id());
+    let output = process::Command::new("starknet-compile")
+        .arg("--version")
+        .output();
+
+    if let Ok(result) = output {
+        if result.status.success() {
+            let version = String::from_utf8(result.stdout)?;
+            println!("Found local cairo installation {}", version);
+            // We have to check the version because if it's >= 2.1.0 the compiler needs --single-file flag
+            let version: Vec<&str> = version
+                .split_whitespace()
+                .nth(1)
+                .unwrap()
+                .split('.')
+                .collect();
+            if version[0] >= "2" && version[1] >= "1" {
+                return local_compiler(opts, true);
+            }
+
+            return local_compiler(opts, false);
+        }
+    }
+
+    println!(
+        "Local cairo installation not found. Compiling with starknet-compile {}",
+        current_compiler_version_id()
+    );
 
     // corelib cli option has priority over the environment variable
     let corelib = match opts.corelib {
@@ -73,4 +103,43 @@ pub fn compile(opts: CoreOpts) -> Result<Vec<ProgramCompiled>> {
     let sierra = replace_sierra_ids_in_program(&db, &sierra);
 
     Ok(vec![ProgramCompiled { sierra, abi }])
+}
+
+fn local_compiler(opts: CoreOpts, single_file_flag: bool) -> Result<Vec<ProgramCompiled>> {
+    let output = if single_file_flag {
+        process::Command::new("starknet-compile")
+            .arg("--single-file")
+            .arg(opts.target)
+            .arg("--replace-ids")
+            .output()?
+    } else {
+        process::Command::new("starknet-compile")
+            .arg(opts.target)
+            .arg("--replace-ids")
+            .output()?
+    };
+
+    if !output.status.success() {
+        bail!(anyhow!(
+            "starknet-compile failed to compile.\n Status {}\n {}",
+            output.status,
+            String::from_utf8(output.stderr)?
+        ));
+    }
+
+    let contract_class: ContractClass =
+        serde_json::from_str(&String::from_utf8(output.stdout)?).unwrap();
+
+    // We don't have to check the existence because we ran the compiler with --replace-ids
+    let debug_info = contract_class.sierra_program_debug_info.unwrap();
+
+    let sierra = sierra_from_felt252s(&contract_class.sierra_program)
+        .unwrap()
+        .2;
+    let sierra = SierraProgramDebugReplacer { debug_info }.apply(&sierra);
+
+    Ok(vec![ProgramCompiled {
+        sierra,
+        abi: contract_class.abi.unwrap(),
+    }])
 }


### PR DESCRIPTION
When analyzing a single cairo file the local cairo compiler binary is used if available otherwise the bundled compiler is used as before.