### PR TITLE
Handle calls to self declared external functions

### DIFF
--- a/src/analysis/reentrancy.rs
+++ b/src/analysis/reentrancy.rs
@@ -143,7 +143,8 @@ impl ReentrancyAnalysis {
                                     Type::Event => {
                                         inner_state.events.insert(basic_block.clone());
                                     }
-                                    Type::Private | Type::Loop => {
+                                    // External and View are needed because it's possible to call self declared external functions within a private function
+                                    Type::Private | Type::Loop | Type::External | Type::View => {
                                         if let GenStatement::Invocation(invoc) =
                                             instruction.get_statement()
                                         {

--- a/src/core/function.rs
+++ b/src/core/function.rs
@@ -74,7 +74,7 @@ pub struct Function {
     storage_vars_written: Vec<SierraStatement>,
     /// Core functions called
     core_functions_calls: Vec<SierraStatement>,
-    /// Private functions called
+    /// Private functions called + calls to self declared External/View functions
     private_functions_calls: Vec<SierraStatement>,
     /// Events emitted (NOTE it doesn't have events emitted using the syscall directly)
     events_emitted: Vec<SierraStatement>,
@@ -235,7 +235,9 @@ impl Function {
                                 }
                                 Type::Event => self.events_emitted.push(s.clone()),
                                 Type::Core => self.core_functions_calls.push(s.clone()),
-                                Type::Private => self.private_functions_calls.push(s.clone()),
+                                Type::Private | Type::External | Type::View => {
+                                    self.private_functions_calls.push(s.clone())
+                                }
                                 Type::AbiCallContract => {
                                     self.external_functions_calls.push(s.clone())
                                 }


### PR DESCRIPTION
The compiler allows to call external functions declared from a private functions. We didn't consider that case and these calls were missed. Now they are availabe in the `private_functions_calls` of each function.