### PR TITLE
Avoid duplicates in detectors results

### DIFF
--- a/src/detectors/array_use_after_pop_front.rs
+++ b/src/detectors/array_use_after_pop_front.rs
@@ -29,8 +29,8 @@ impl Detector for ArrayUseAfterPopFront {
         Impact::Low
     }
 
-    fn run(&self, core: &CoreUnit) -> Vec<Result> {
-        let mut results = Vec::new();
+    fn run(&self, core: &CoreUnit) -> HashSet<Result> {
+        let mut results: HashSet<Result> = HashSet::new();
         let compilation_units = core.get_compilation_units();
 
         for compilation_unit in compilation_units.iter() {
@@ -92,7 +92,7 @@ impl Detector for ArrayUseAfterPopFront {
                             &function.name()
                         )
                     };
-                    results.push(Result {
+                    results.insert(Result {
                         name: self.name().to_string(),
                         impact: self.impact(),
                         confidence: self.confidence(),

--- a/src/detectors/controlled_library_call.rs
+++ b/src/detectors/controlled_library_call.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use super::detector::{Confidence, Detector, Impact, Result};
 use crate::core::compilation_unit::CompilationUnit;
 use crate::core::core_unit::CoreUnit;
@@ -28,8 +30,8 @@ impl Detector for ControlledLibraryCall {
         Impact::High
     }
 
-    fn run(&self, core: &CoreUnit) -> Vec<Result> {
-        let mut results = Vec::new();
+    fn run(&self, core: &CoreUnit) -> HashSet<Result> {
+        let mut results: HashSet<Result> = HashSet::new();
         let compilation_units = core.get_compilation_units();
 
         for compilation_unit in compilation_units {
@@ -92,7 +94,7 @@ impl Detector for ControlledLibraryCall {
 impl ControlledLibraryCall {
     fn check_user_controlled(
         &self,
-        results: &mut Vec<Result>,
+        results: &mut HashSet<Result>,
         formal_params: &[ParamSignature],
         actual_params: Vec<VarId>,
         compilation_unit: &CompilationUnit,
@@ -108,7 +110,7 @@ impl ControlledLibraryCall {
                 "Library call to user controlled class hash in {}\n {}",
                 function_name, statement
             );
-            results.push(Result {
+            results.insert(Result {
                 name: self.name().to_string(),
                 impact: self.impact(),
                 confidence: self.confidence(),

--- a/src/detectors/dead_code.rs
+++ b/src/detectors/dead_code.rs
@@ -27,8 +27,8 @@ impl Detector for DeadCode {
         Impact::Low
     }
 
-    fn run(&self, core: &CoreUnit) -> Vec<Result> {
-        let mut results = Vec::new();
+    fn run(&self, core: &CoreUnit) -> HashSet<Result> {
+        let mut results: HashSet<Result> = HashSet::new();
         let compilation_units = core.get_compilation_units();
 
         for compilation_unit in compilation_units {
@@ -70,7 +70,7 @@ impl Detector for DeadCode {
                 .iter()
                 .map(|private_function| private_function.rsplit_once("::").unwrap())
                 .for_each(|(function_declaration, function_name)| {
-                    results.push(Result {
+                    results.insert(Result {
                         name: self.name().to_string(),
                         impact: self.impact(),
                         confidence: self.confidence(),
@@ -78,7 +78,7 @@ impl Detector for DeadCode {
                             "Function {} defined in {} is never used",
                             function_name, function_declaration
                         ),
-                    })
+                    });
                 });
         }
         results

--- a/src/detectors/detector.rs
+++ b/src/detectors/detector.rs
@@ -1,13 +1,13 @@
 use crate::core::core_unit::CoreUnit;
 
-use std::fmt;
+use std::{collections::HashSet, fmt};
 
 pub trait Detector {
     fn name(&self) -> &str;
     fn description(&self) -> &str;
     fn impact(&self) -> Impact;
     fn confidence(&self) -> Confidence;
-    fn run(&self, core: &CoreUnit) -> Vec<Result>;
+    fn run(&self, core: &CoreUnit) -> HashSet<Result>;
 }
 
 impl fmt::Display for dyn Detector {

--- a/src/detectors/felt252_overflow.rs
+++ b/src/detectors/felt252_overflow.rs
@@ -30,8 +30,8 @@ impl Detector for Felt252Overflow {
         Impact::Medium
     }
 
-    fn run(&self, core: &CoreUnit) -> Vec<Result> {
-        let mut results = Vec::new();
+    fn run(&self, core: &CoreUnit) -> HashSet<Result> {
+        let mut results: HashSet<Result> = HashSet::new();
 
         let compilation_units = core.get_compilation_units();
         for compilation_unit in compilation_units {
@@ -93,7 +93,7 @@ impl Detector for Felt252Overflow {
 impl Felt252Overflow {
     fn check_felt252_tainted(
         &self,
-        results: &mut Vec<Result>,
+        results: &mut HashSet<Result>,
         compilation_unit: &CompilationUnit,
         libfunc: &SierraStatement,
         args: &[VarId],
@@ -119,7 +119,7 @@ impl Felt252Overflow {
                 "The function {} uses the felt252 operation {}, which is not overflow/underflow safe",
                 &name, libfunc
             );
-            results.push(Result {
+            results.insert(Result {
                 name: self.name().to_string(),
                 impact: self.impact(),
                 confidence: self.confidence(),
@@ -132,7 +132,7 @@ impl Felt252Overflow {
                     libfunc,
                     taints
                 );
-            results.push(Result {
+            results.insert(Result {
                 name: self.name().to_string(),
                 impact: self.impact(),
                 confidence: self.confidence(),
@@ -143,7 +143,7 @@ impl Felt252Overflow {
     #[allow(clippy::too_many_arguments)]
     fn handle_binops(
         &self,
-        results: &mut Vec<Result>,
+        results: &mut HashSet<Result>,
         compilation_unit: &CompilationUnit,
         invoc: &GenInvocation<StatementIdx>,
         statements: &[SierraStatement],

--- a/src/detectors/read_only_reentrancy.rs
+++ b/src/detectors/read_only_reentrancy.rs
@@ -26,7 +26,7 @@ impl Detector for ReadOnlyReentrancy {
         Impact::Medium
     }
 
-    fn run(&self, core: &CoreUnit) -> Vec<Result> {
+    fn run(&self, core: &CoreUnit) -> HashSet<Result> {
         let mut results: HashSet<Result> = HashSet::new();
         let compilation_units = core.get_compilation_units();
 
@@ -104,6 +104,6 @@ impl Detector for ReadOnlyReentrancy {
             }
         }
 
-        Vec::from_iter(results)
+        results
     }
 }

--- a/src/detectors/reentrancy.rs
+++ b/src/detectors/reentrancy.rs
@@ -25,7 +25,7 @@ impl Detector for Reentrancy {
         Impact::Medium
     }
 
-    fn run(&self, core: &CoreUnit) -> Vec<Result> {
+    fn run(&self, core: &CoreUnit) -> HashSet<Result> {
         let mut results: HashSet<Result> = HashSet::new();
         let compilation_units = core.get_compilation_units();
 
@@ -101,6 +101,6 @@ impl Detector for Reentrancy {
             }
         }
 
-        Vec::from_iter(results)
+        results
     }
 }

--- a/src/detectors/reentrancy_benign.rs
+++ b/src/detectors/reentrancy_benign.rs
@@ -25,7 +25,7 @@ impl Detector for ReentrancyBenign {
         Impact::Low
     }
 
-    fn run(&self, core: &CoreUnit) -> Vec<Result> {
+    fn run(&self, core: &CoreUnit) -> HashSet<Result> {
         let mut results: HashSet<Result> = HashSet::new();
         let compilation_units = core.get_compilation_units();
 
@@ -101,6 +101,6 @@ impl Detector for ReentrancyBenign {
             }
         }
 
-        Vec::from_iter(results)
+        results
     }
 }

--- a/src/detectors/reentrancy_events.rs
+++ b/src/detectors/reentrancy_events.rs
@@ -25,7 +25,7 @@ impl Detector for ReentrancyEvents {
         Impact::Low
     }
 
-    fn run(&self, core: &CoreUnit) -> Vec<Result> {
+    fn run(&self, core: &CoreUnit) -> HashSet<Result> {
         let mut results: HashSet<Result> = HashSet::new();
         let compilation_units = core.get_compilation_units();
 
@@ -62,6 +62,6 @@ impl Detector for ReentrancyEvents {
             }
         }
 
-        Vec::from_iter(results)
+        results
     }
 }

--- a/src/detectors/unchecked_l1_handler_from.rs
+++ b/src/detectors/unchecked_l1_handler_from.rs
@@ -29,8 +29,8 @@ impl Detector for UncheckedL1HandlerFrom {
         Impact::High
     }
 
-    fn run(&self, core: &CoreUnit) -> Vec<Result> {
-        let mut results = Vec::new();
+    fn run(&self, core: &CoreUnit) -> HashSet<Result> {
+        let mut results: HashSet<Result> = HashSet::new();
         let compilation_units = core.get_compilation_units();
 
         for compilation_unit in compilation_units {
@@ -61,7 +61,7 @@ impl Detector for UncheckedL1HandlerFrom {
                         "The L1 handler function {} does not check the L1 from address",
                         &f.name()
                     );
-                    results.push(Result {
+                    results.insert(Result {
                         name: self.name().to_string(),
                         impact: self.impact(),
                         confidence: self.confidence(),

--- a/src/detectors/unused_arguments.rs
+++ b/src/detectors/unused_arguments.rs
@@ -3,6 +3,7 @@ use crate::core::core_unit::CoreUnit;
 use crate::utils::number_to_ordinal;
 use cairo_lang_sierra::extensions::core::CoreConcreteLibfunc;
 use cairo_lang_sierra::program::Statement as SierraStatement;
+use std::collections::HashSet;
 
 // Note: It doesn't work correctly when arguments are passed by reference
 
@@ -26,8 +27,8 @@ impl Detector for UnusedArguments {
         Impact::Low
     }
 
-    fn run(&self, core: &CoreUnit) -> Vec<Result> {
-        let mut results = Vec::new();
+    fn run(&self, core: &CoreUnit) -> HashSet<Result> {
+        let mut results: HashSet<Result> = HashSet::new();
         let compilation_units = core.get_compilation_units();
 
         for compilation_unit in compilation_units {
@@ -56,7 +57,7 @@ impl Detector for UnusedArguments {
                                 .as_str()
                                 .ends_with("::ContractState")
                             {
-                                results.push(Result {
+                                results.insert(Result {
                                     name: self.name().to_string(),
                                     impact: self.impact(),
                                     confidence: self.confidence(),
@@ -65,7 +66,7 @@ impl Detector for UnusedArguments {
                                         number_to_ordinal(invoc.args[0].id - offset as u64 + 1),
                                         f.name()
                                     ),
-                                })
+                                });
                             }
                         } else {
                             break;

--- a/src/detectors/unused_events.rs
+++ b/src/detectors/unused_events.rs
@@ -28,8 +28,8 @@ impl Detector for UnusedEvents {
         Impact::Medium
     }
 
-    fn run(&self, core: &CoreUnit) -> Vec<Result> {
-        let mut results = Vec::new();
+    fn run(&self, core: &CoreUnit) -> HashSet<Result> {
+        let mut results: HashSet<Result> = HashSet::new();
         let compilation_units = core.get_compilation_units();
 
         for compilation_unit in compilation_units {
@@ -66,7 +66,7 @@ impl Detector for UnusedEvents {
                 .iter()
                 .map(|event_function| event_function.rsplit_once("::").unwrap())
                 .for_each(|(event_declaration, event_name)| {
-                    results.push(Result {
+                    results.insert(Result {
                         name: self.name().to_string(),
                         impact: self.impact(),
                         confidence: self.confidence(),
@@ -74,7 +74,7 @@ impl Detector for UnusedEvents {
                             "Event {} defined in {} is never emitted",
                             event_name, event_declaration
                         ),
-                    })
+                    });
                 });
         }
         results

--- a/src/detectors/unused_return.rs
+++ b/src/detectors/unused_return.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use super::detector::{Confidence, Detector, Impact, Result};
 use crate::core::compilation_unit::CompilationUnit;
 use crate::core::core_unit::CoreUnit;
@@ -28,8 +30,8 @@ impl Detector for UnusedReturn {
         Impact::Medium
     }
 
-    fn run(&self, core: &CoreUnit) -> Vec<Result> {
-        let mut results = Vec::new();
+    fn run(&self, core: &CoreUnit) -> HashSet<Result> {
+        let mut results: HashSet<Result> = HashSet::new();
         let compilation_units = core.get_compilation_units();
 
         for compilation_unit in compilation_units {
@@ -91,7 +93,7 @@ impl Detector for UnusedReturn {
                                     let info = ty_dropped.info();
                                     // If size is 0 it's the Unit type
                                     if !info.zero_sized {
-                                        results.push(Result {
+                                        results.insert(Result {
                                             name: self.name().to_string(),
                                             impact: self.impact(),
                                             confidence: self.confidence(),
@@ -166,7 +168,7 @@ impl<'a> UnusedReturn {
     fn iterate_struct_deconstruct(
         &self,
         compilation_unit: &'a CompilationUnit,
-        results: &mut Vec<Result>,
+        results: &mut HashSet<Result>,
         mut libfunc: &'a CoreConcreteLibfunc,
         mut stmt_to_check: &[GenStatement<StatementIdx>],
         stmt: &GenStatement<StatementIdx>,
@@ -203,7 +205,7 @@ impl<'a> UnusedReturn {
             let info = ty_dropped.info();
             // If size is 0 it's the Unit type
             if !info.zero_sized {
-                results.push(Result {
+                results.insert(Result {
                     name: self.name().to_string(),
                     impact: self.impact(),
                     confidence: self.confidence(),


### PR DESCRIPTION
Duplicates can happen when there are multiple compilation units that use the same code