### PR TITLE
Improve taint

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "sarif-viewer.connectToGithubCodeScanning": "off"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "sarif-viewer.connectToGithubCodeScanning": "off"
-}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,6 +227,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "cairo-felt"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -637,6 +643,7 @@ dependencies = [
  "cairo-lang-syntax",
  "cairo-lang-utils",
  "clap",
+ "fxhash",
  "graphviz-rust",
  "insta",
  "num-bigint",
@@ -978,6 +985,15 @@ name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
 
 [[package]]
 name = "genco"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ graphviz-rust = "0.6.2"
 cairo-felt = "0.8.7"
 thiserror = "1.0.47"
 rayon = "1.8"
+fxhash = "0.2.1"
 
 cairo-lang-compiler = { git = "https://github.com/starkware-libs/cairo.git", tag = "v2.4.3" }
 cairo-lang-defs = { git = "https://github.com/starkware-libs/cairo.git", tag = "v2.4.3" }
@@ -32,6 +33,7 @@ cairo-lang-semantic = { git = "https://github.com/starkware-libs/cairo.git", tag
 cairo-lang-utils = { git = "https://github.com/starkware-libs/cairo.git", tag = "v2.4.3" }
 cairo-lang-sierra-generator = { git = "https://github.com/starkware-libs/cairo.git", tag = "v2.4.3" }
 cairo-lang-sierra = { git = "https://github.com/starkware-libs/cairo.git", tag = "v2.4.3" }
+
 
 [dev-dependencies]
 insta = { version = "1.30", features = ["glob"] }

--- a/src/analysis/taint.rs
+++ b/src/analysis/taint.rs
@@ -1,8 +1,6 @@
-use cairo_lang_sierra::{
-    ids::VarId,
-    program::{GenStatement, Statement as SierraStatement},
-};
-use fxhash::{FxHashMap,FxHashSet};
+use cairo_lang_sierra::program::{GenStatement, Statement as SierraStatement};
+use fxhash::{FxHashMap, FxHashSet};
+
 /// Wrapper around a VarId
 /// it's used to univocally identify variables
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -10,11 +8,11 @@ pub struct WrapperVariable {
     /// The function where the variable appear
     function: String,
     /// The variable's id
-    variable: VarId,
+    variable: u64,
 }
 
 impl WrapperVariable {
-    pub fn new(function: String, variable: VarId) -> Self {
+    pub fn new(function: String, variable: u64) -> Self {
         WrapperVariable { function, variable }
     }
 
@@ -24,8 +22,8 @@ impl WrapperVariable {
     }
 
     /// Return the variable
-    pub fn variable(&self) -> &VarId {
-        &self.variable
+    pub fn variable(&self) -> u64 {
+        self.variable
     }
 }
 
@@ -139,12 +137,12 @@ fn analyze(
                     let sinks = map
                         .entry(WrapperVariable {
                             function: function.clone(),
-                            variable: source.clone(),
+                            variable: source.id,
                         })
                         .or_default();
                     sinks.insert(WrapperVariable {
                         function: function.clone(),
-                        variable: sink.clone(),
+                        variable: sink.id,
                     });
                 }
             }

--- a/src/analysis/taint.rs
+++ b/src/analysis/taint.rs
@@ -2,8 +2,7 @@ use cairo_lang_sierra::{
     ids::VarId,
     program::{GenStatement, Statement as SierraStatement},
 };
-use std::collections::{HashMap, HashSet};
-
+use fxhash::{FxHashMap,FxHashSet};
 /// Wrapper around a VarId
 /// it's used to univocally identify variables
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -35,26 +34,26 @@ pub struct Taint {
     /// Source WrapperVariable to set of sink WrapperVariable
     /// e.g. instruction reads variables 3, 4 and has 5 as output
     /// we will add (3, (5)) and (4, (5)); variable 5 is tainted by 3 and 4
-    map: HashMap<WrapperVariable, HashSet<WrapperVariable>>,
+    map: FxHashMap<WrapperVariable, FxHashSet<WrapperVariable>>,
 }
 
 impl Taint {
     pub fn new(instructions: &[SierraStatement], function: String) -> Self {
-        let mut map = HashMap::new();
+        let mut map = FxHashMap::default();
         analyze(&mut map, instructions, function);
 
         Taint { map }
     }
 
     /// Returns variables tainted in a single step by source
-    pub fn single_step_taint(&self, source: &WrapperVariable) -> HashSet<WrapperVariable> {
+    pub fn single_step_taint(&self, source: &WrapperVariable) -> FxHashSet<WrapperVariable> {
         self.map.get(source).cloned().unwrap_or_default()
     }
 
     /// Returns variables tainted in zero or more steps by source
-    pub fn multi_step_taint(&self, source: &WrapperVariable) -> HashSet<WrapperVariable> {
-        let mut result = HashSet::new();
-        let mut update = HashSet::from([source.clone()]);
+    pub fn multi_step_taint(&self, source: &WrapperVariable) -> FxHashSet<WrapperVariable> {
+        let mut result = FxHashSet::default();
+        let mut update = FxHashSet::from_iter([source.clone()]);
         while !update.is_subset(&result) {
             result.extend(update.iter().cloned());
             update = update
@@ -69,7 +68,7 @@ impl Taint {
     pub fn taints_any_sinks_variable(
         &self,
         source: &WrapperVariable,
-        sinks: &HashSet<WrapperVariable>,
+        sinks: &FxHashSet<WrapperVariable>,
     ) -> Vec<WrapperVariable> {
         self.multi_step_taint(source)
             .into_iter()
@@ -81,7 +80,7 @@ impl Taint {
     pub fn taints_any_sinks(
         &self,
         source: &WrapperVariable,
-        sinks: &HashSet<WrapperVariable>,
+        sinks: &FxHashSet<WrapperVariable>,
     ) -> bool {
         self.multi_step_taint(source)
             .iter()
@@ -91,7 +90,7 @@ impl Taint {
     /// Returns the sources that taint the sink
     pub fn taints_any_sources_variable(
         &self,
-        sources: &HashSet<WrapperVariable>,
+        sources: &FxHashSet<WrapperVariable>,
         sink: &WrapperVariable,
     ) -> Vec<WrapperVariable> {
         sources
@@ -104,7 +103,7 @@ impl Taint {
     /// Returns true if the sink is tainted by any source
     pub fn taints_any_sources(
         &self,
-        sources: &HashSet<WrapperVariable>,
+        sources: &FxHashSet<WrapperVariable>,
         sink: &WrapperVariable,
     ) -> bool {
         sources
@@ -121,7 +120,7 @@ impl Taint {
 
 /// Analyze each instruction in the current function and populate the taint map
 fn analyze(
-    map: &mut HashMap<WrapperVariable, HashSet<WrapperVariable>>,
+    map: &mut FxHashMap<WrapperVariable, FxHashSet<WrapperVariable>>,
     instructions: &[SierraStatement],
     function: String,
 ) {

--- a/src/core/compilation_unit.rs
+++ b/src/core/compilation_unit.rs
@@ -13,7 +13,6 @@ use cairo_lang_starknet::abi::{
 };
 use fxhash::FxHashSet;
 use std::collections::{HashMap, HashSet};
-use std::time::Instant;
 
 pub struct CompilationUnit {
     /// The compiled sierra program

--- a/src/core/core_unit.rs
+++ b/src/core/core_unit.rs
@@ -31,7 +31,6 @@ impl CoreUnit {
                 compilation_unit
             })
             .collect();
-
         Ok(CoreUnit { compilation_units })
     }
 

--- a/src/detectors/array_use_after_pop_front.rs
+++ b/src/detectors/array_use_after_pop_front.rs
@@ -1,5 +1,6 @@
-use std::collections::HashSet;
 
+use fxhash::FxHashSet;
+use std::collections::HashSet;
 use super::detector::{Confidence, Detector, Impact, Result};
 use crate::analysis::taint::WrapperVariable;
 use crate::core::compilation_unit::CompilationUnit;
@@ -163,7 +164,7 @@ impl ArrayUseAfterPopFront {
 
                 match libfunc {
                     CoreConcreteLibfunc::Array(ArrayConcreteLibfunc::Append(_)) => {
-                        let mut sinks = HashSet::new();
+                        let mut sinks = FxHashSet::default();
                         sinks.insert(WrapperVariable::new(function.name(), invoc.args[0].clone()));
 
                         taint.taints_any_sinks(bad_array, &sinks)
@@ -192,7 +193,7 @@ impl ArrayUseAfterPopFront {
                     .expect("Library function not found in the registry");
 
                 if let CoreConcreteLibfunc::FunctionCall(_) = lib_func {
-                    let sinks: HashSet<WrapperVariable> = invoc
+                    let sinks: FxHashSet<WrapperVariable> = invoc
                         .args
                         .iter()
                         .map(|v| WrapperVariable::new(function.name(), v.clone()))
@@ -325,14 +326,14 @@ impl ArrayUseAfterPopFront {
             return false;
         }
 
-        // Not sure if it is required because taint analysis adds all the arugments as
+        // Not sure if it is required because taint analysis adds all the arguments as
         // tainters of the all the return values.
         let returned_bad_arrays: Vec<WrapperVariable> = function
             .get_statements()
             .iter()
             .flat_map(|s| {
                 if let GenStatement::Return(return_vars) = s {
-                    let sinks: HashSet<WrapperVariable> = return_vars
+                    let sinks: FxHashSet<WrapperVariable> = return_vars
                         .iter()
                         .map(|v| WrapperVariable::new(function.name(), v.clone()))
                         .collect();

--- a/src/detectors/unchecked_l1_handler_from.rs
+++ b/src/detectors/unchecked_l1_handler_from.rs
@@ -1,5 +1,5 @@
 use std::collections::HashSet;
-
+use fxhash::FxHashSet;
 use super::detector::{Confidence, Detector, Impact, Result};
 use crate::analysis::taint::WrapperVariable;
 use crate::core::compilation_unit::CompilationUnit;
@@ -42,7 +42,7 @@ impl Detector for UncheckedL1HandlerFrom {
             for f in l1_handler_funcs {
                 let from_address =
                     f.params().map(|p| p.id.clone()).collect::<Vec<VarId>>()[1].clone();
-                let mut sources = HashSet::new();
+                let mut sources = FxHashSet::default();
                 sources.insert(WrapperVariable::new(f.name(), from_address));
 
                 // Used to avoid infinite recursion in case of recursive private function calls
@@ -78,7 +78,7 @@ impl Detector for UncheckedL1HandlerFrom {
 impl UncheckedL1HandlerFrom {
     fn is_from_checked_in_function(
         &self,
-        from_tainted_args: &HashSet<WrapperVariable>,
+        from_tainted_args: &FxHashSet<WrapperVariable>,
         compilation_unit: &CompilationUnit,
         function: &Function,
         checked_private_functions: &mut HashSet<String>,
@@ -98,7 +98,7 @@ impl UncheckedL1HandlerFrom {
 
                 match libfunc {
                     CoreConcreteLibfunc::Felt252(Felt252Concrete::IsZero(_)) => self
-                        .is_felt252_is_zero_arg_taintaed_by_from_address(
+                        .is_felt252_is_zero_arg_tainted_by_from_address(
                             from_tainted_args,
                             invoc.args.clone(),
                             compilation_unit,
@@ -126,13 +126,13 @@ impl UncheckedL1HandlerFrom {
 
                         let taint = compilation_unit.get_taint(&function.name()).unwrap();
 
-                        let sinks: HashSet<WrapperVariable> = invoc
+                        let sinks: FxHashSet<WrapperVariable> = invoc
                             .args
                             .iter()
                             .map(|v| WrapperVariable::new(function.name(), v.clone()))
                             .collect();
 
-                        let from_tainted_args: HashSet<WrapperVariable> = from_tainted_args
+                        let from_tainted_args: FxHashSet<WrapperVariable> = from_tainted_args
                             .iter()
                             .flat_map(|source| taint.taints_any_sinks_variable(source, &sinks))
                             .map(|sink| {
@@ -158,9 +158,9 @@ impl UncheckedL1HandlerFrom {
         from_checked_in_private_functions
     }
 
-    fn is_felt252_is_zero_arg_taintaed_by_from_address(
+    fn is_felt252_is_zero_arg_tainted_by_from_address(
         &self,
-        sources: &HashSet<WrapperVariable>,
+        sources: &FxHashSet<WrapperVariable>,
         felt252_is_zero_args: Vec<VarId>,
         compilation_unit: &CompilationUnit,
         function_name: &str,


### PR DESCRIPTION
Speeds up taint analysis by using `FxHash`, a faster hashing algorithm than the default one in `HashMap`. Also uses the raw variable id instead of the entire `VarId` struct. 